### PR TITLE
[Add] migration for model index

### DIFF
--- a/migrations/V0002__add_model_index.sql
+++ b/migrations/V0002__add_model_index.sql
@@ -1,0 +1,1 @@
+CREATE INDEX idx_type_status ON model (type, status);


### PR DESCRIPTION
## description 
improve query speed for following report:
> the article rec API is much slower when querying for “current” than when querying for specific model IDs 