### PR TITLE
Add site column to articles table

### DIFF
--- a/migrations/V0003__add_site.sql
+++ b/migrations/V0003__add_site.sql
@@ -1,0 +1,7 @@
+-- external ids are no longer unique in multitenant setup
+DROP INDEX uq_external_id;
+
+ALTER TABLE article
+    ADD site text,
+    ADD CONSTRAINT uq_site_external_id UNIQUE (site, external_id);
+


### PR DESCRIPTION
This pull request adds the `site` column to the database in one of two migrations. The goal is to get to a database state where all existing and incoming rows are correctly populated by the training job with `site=washington-city-paper`, and a not-null constraint is applied so that all application layer code must correctly pass a `site` value when creating new rows in the articles table.

Migration `V0003` (in this PR): adds the site column and adjusts the indexes, as we now guarantee site+external_id uniqueness instead of just uniqueness on external_id.

Migration `V0004` (https://github.com/LocalAtBrown/article-rec-db/pull/3) populates all the existing rows of the database with `site=washington-city-paper` and adds a not-null constraint to the `site` column.

By breaking it up into two migrations, we can decouple the dependencies and execute in the following steps:
1. run `V0003` without breaking anything
2. develop and deploy the article training job change to write the `site` column when creating new articles
3. run `V0004` without breaking anything
4. profit

Test plan:
I executed the first migration on dev tier with `kar flyway dev migrate -target 0003` and confirmed that it added the `site` column as expected:

<img width="473" alt="image" src="https://user-images.githubusercontent.com/6618711/136075185-d7d21bfa-6db5-44f8-8ba4-69101e90829c.png">
