### PR TITLE
Add table privileges

### DIFF
--- a/terraform/modules/db/main.tf
+++ b/terraform/modules/db/main.tf
@@ -1,12 +1,27 @@
 locals {
   sites                  = toset(var.sites)
+  schema                 = "public"
   password_special_chars = "!@$"
   tables = {
-    "page"           = {}
-    "article"        = {}
-    "execution"      = {}
-    "embedding"      = {}
-    "recommendation" = {}
+    "page"           = "page"
+    "article"        = "article"
+    "execution"      = "execution"
+    "embedding"      = "embedding"
+    "recommendation" = "recommendation"
+  }
+}
+
+locals {
+  training_job_privileges = {
+    "table" = {
+      "SELECT" = keys(local.tables)
+      "INSERT" = keys(local.tables)
+      "UPDATE" = [local.tables.page, local.tables.article]
+      "DELETE" = keys(local.tables)
+    }
+  }
+  reader_privileges = {
+    "table" = { "SELECT" = keys(local.tables) }
   }
 }
 
@@ -25,6 +40,17 @@ resource "postgresql_extension" "pgvector" {
 resource "postgresql_role" "training_job" {
   name  = "${var.stage}_training_job"
   login = false
+}
+
+resource "postgresql_grant" "training_job_table_privileges" {
+  for_each = local.training_job_privileges.table
+
+  database    = postgresql_database.db.name
+  role        = postgresql_role.training_job.name
+  schema      = local.schema
+  object_type = "table"
+  objects     = each.value
+  privileges  = [each.key]
 }
 
 resource "random_password" "training_job_site_password" {
@@ -71,13 +97,15 @@ resource "postgresql_role" "reader" {
   password = random_password.reader_password.result
 }
 
-resource "postgresql_grant" "readonly_tables" {
+resource "postgresql_grant" "reader_table_privileges" {
+  for_each = local.reader_privileges.table
+
   database    = postgresql_database.db.name
   role        = postgresql_role.reader.name
-  schema      = "public"
+  schema      = local.schema
   object_type = "table"
-  objects     = keys(local.tables)
-  privileges  = ["SELECT"]
+  objects     = each.value
+  privileges  = [each.key]
 }
 
 resource "aws_ssm_parameter" "reader_credentials" {

--- a/terraform/modules/db/main.tf
+++ b/terraform/modules/db/main.tf
@@ -1,9 +1,24 @@
 locals {
-  sites = toset(var.sites)
+  sites                  = toset(var.sites)
+  password_special_chars = "!@$"
+  tables = {
+    "page"           = {}
+    "article"        = {}
+    "execution"      = {}
+    "embedding"      = {}
+    "recommendation" = {}
+  }
 }
 
 resource "postgresql_database" "db" {
   name = var.stage
+}
+
+# Enable extensions
+resource "postgresql_extension" "pgvector" {
+  name     = "vector"
+  version  = "0.4.1"
+  database = postgresql_database.db.name
 }
 
 # Training job role and site users
@@ -17,7 +32,7 @@ resource "random_password" "training_job_site_password" {
 
   length           = 20
   special          = true
-  override_special = "!@$"
+  override_special = local.password_special_chars
 }
 
 resource "postgresql_role" "training_job_site" {
@@ -43,9 +58,36 @@ resource "aws_ssm_parameter" "training_job_site_credentials" {
   })
 }
 
-# Enable extensions
-resource "postgresql_extension" "pgvector" {
-  name     = "vector"
-  version  = "0.4.1"
-  database = postgresql_database.db.name
+# Read-only role and user
+resource "random_password" "reader_password" {
+  length           = 20
+  special          = true
+  override_special = local.password_special_chars
+}
+
+resource "postgresql_role" "reader" {
+  name     = "${var.stage}_reader"
+  login    = true
+  password = random_password.reader_password.result
+}
+
+resource "postgresql_grant" "readonly_tables" {
+  database    = postgresql_database.db.name
+  role        = postgresql_role.reader.name
+  schema      = "public"
+  object_type = "table"
+  objects     = keys(local.tables)
+  privileges  = ["SELECT"]
+}
+
+resource "aws_ssm_parameter" "reader_credentials" {
+  name = "/${var.stage}/article-rec/reader/all/database-credentials"
+  type = "String"
+  value = jsonencode({
+    HOST     = var.host
+    PORT     = var.port
+    DB_NAME  = var.stage
+    USERNAME = postgresql_role.reader.name
+    PASSWORD = random_password.reader_password.result
+  })
 }


### PR DESCRIPTION
## Description

Adds training job roles' table privileges. In addition, creates a new read-only login role.

### Terraform
```bash
❯ poe terraform dev plan
Poe => terraform -chdir=terraform/stages/dev plan
module.db.random_password.training_job_site_password["afro-la"]: Refreshing state... [id=none]
module.db.random_password.training_job_site_password["dallas-free-press"]: Refreshing state... [id=none]
data.aws_ssm_parameter.credentials_admin: Reading...
data.aws_ssm_parameter.credentials_admin: Read complete after 0s [id=/dev/article-rec/admin/all/database-credentials]
module.db.postgresql_database.db: Refreshing state... [id=dev]
module.db.postgresql_role.training_job: Refreshing state... [id=dev_training_job]
module.db.postgresql_role.training_job_site["afro-la"]: Refreshing state... [id=dev_training_job_afro_la]
module.db.postgresql_role.training_job_site["dallas-free-press"]: Refreshing state... [id=dev_training_job_dallas_free_press]
module.db.aws_ssm_parameter.training_job_site_credentials["afro-la"]: Refreshing state... [id=/dev/article-rec/afro-la/training-job/database-credentials]
module.db.aws_ssm_parameter.training_job_site_credentials["dallas-free-press"]: Refreshing state... [id=/dev/article-rec/dallas-free-press/training-job/database-credentials]
module.db.postgresql_extension.pgvector: Refreshing state... [id=dev.vector]

Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with the following symbols:
  + create

Terraform will perform the following actions:

  # module.db.aws_ssm_parameter.reader_credentials will be created
  + resource "aws_ssm_parameter" "reader_credentials" {
      + arn            = (known after apply)
      + data_type      = (known after apply)
      + id             = (known after apply)
      + insecure_value = (known after apply)
      + key_id         = (known after apply)
      + name           = "/dev/article-rec/reader/all/database-credentials"
      + tags_all       = (known after apply)
      + tier           = (known after apply)
      + type           = "String"
      + value          = (sensitive value)
      + version        = (known after apply)
    }

  # module.db.postgresql_grant.reader_table_privileges["SELECT"] will be created
  + resource "postgresql_grant" "reader_table_privileges" {
      + database          = "dev"
      + id                = (known after apply)
      + object_type       = "table"
      + objects           = [
          + "article",
          + "embedding",
          + "execution",
          + "page",
          + "recommendation",
        ]
      + privileges        = [
          + "SELECT",
        ]
      + role              = "dev_reader"
      + schema            = "public"
      + with_grant_option = false
    }

  # module.db.postgresql_grant.training_job_table_privileges["DELETE"] will be created
  + resource "postgresql_grant" "training_job_table_privileges" {
      + database          = "dev"
      + id                = (known after apply)
      + object_type       = "table"
      + objects           = [
          + "article",
          + "embedding",
          + "execution",
          + "page",
          + "recommendation",
        ]
      + privileges        = [
          + "DELETE",
        ]
      + role              = "dev_training_job"
      + schema            = "public"
      + with_grant_option = false
    }

  # module.db.postgresql_grant.training_job_table_privileges["INSERT"] will be created
  + resource "postgresql_grant" "training_job_table_privileges" {
      + database          = "dev"
      + id                = (known after apply)
      + object_type       = "table"
      + objects           = [
          + "article",
          + "embedding",
          + "execution",
          + "page",
          + "recommendation",
        ]
      + privileges        = [
          + "INSERT",
        ]
      + role              = "dev_training_job"
      + schema            = "public"
      + with_grant_option = false
    }

  # module.db.postgresql_grant.training_job_table_privileges["SELECT"] will be created
  + resource "postgresql_grant" "training_job_table_privileges" {
      + database          = "dev"
      + id                = (known after apply)
      + object_type       = "table"
      + objects           = [
          + "article",
          + "embedding",
          + "execution",
          + "page",
          + "recommendation",
        ]
      + privileges        = [
          + "SELECT",
        ]
      + role              = "dev_training_job"
      + schema            = "public"
      + with_grant_option = false
    }

  # module.db.postgresql_grant.training_job_table_privileges["UPDATE"] will be created
  + resource "postgresql_grant" "training_job_table_privileges" {
      + database          = "dev"
      + id                = (known after apply)
      + object_type       = "table"
      + objects           = [
          + "article",
          + "page",
        ]
      + privileges        = [
          + "UPDATE",
        ]
      + role              = "dev_training_job"
      + schema            = "public"
      + with_grant_option = false
    }

  # module.db.postgresql_role.reader will be created
  + resource "postgresql_role" "reader" {
      + bypass_row_level_security = false
      + connection_limit          = -1
      + create_database           = false
      + create_role               = false
      + encrypted_password        = true
      + id                        = (known after apply)
      + inherit                   = true
      + login                     = true
      + name                      = "dev_reader"
      + password                  = (sensitive value)
      + replication               = false
      + skip_drop_role            = false
      + skip_reassign_owned       = false
      + superuser                 = false
      + valid_until               = "infinity"
    }

  # module.db.random_password.reader_password will be created
  + resource "random_password" "reader_password" {
      + bcrypt_hash      = (sensitive value)
      + id               = (known after apply)
      + length           = 20
      + lower            = true
      + min_lower        = 0
      + min_numeric      = 0
      + min_special      = 0
      + min_upper        = 0
      + number           = true
      + numeric          = true
      + override_special = "!@$"
      + result           = (sensitive value)
      + special          = true
      + upper            = true
    }

Plan: 8 to add, 0 to change, 0 to destroy.

```

### Alembic
There were no changes.