### PR TITLE
Cycle recommendation ID sequence

### DIFF
--- a/migrations/V0009__cycle_rec_id.sql
+++ b/migrations/V0009__cycle_rec_id.sql
@@ -1,0 +1,1 @@
+ALTER SEQUENCE recommendation_id_seq CYCLE;


### PR DESCRIPTION
## Description

Cycle `recommendation_id_seq` sequence to its starting point since the largest rec ID is now 2^31. Duplicate IDs shouldn't be an issue since the training job has always been deleting old recs.

Newest migration already applied using my machine.